### PR TITLE
Undo color settings

### DIFF
--- a/janus/vim/tmux.conf
+++ b/janus/vim/tmux.conf
@@ -36,10 +36,6 @@ set -sg escape-time 10
 # automatically renumber tmux windows
 set -g renumber-windows on
 
-set -g default-terminal "xterm-256color"
-set-option -ga terminal-overrides ",xterm-256color:Tc"
-# set-option -sa terminal-overrides ",xterm*:Tc"
-
 set-option -g set-titles on
 set-option -g set-titles-string "#S"
 # set -g terminal-overrides "xterm*:XT:smcup@:rmcup@"


### PR DESCRIPTION
This color setting obfuscate Ack search result in light theme. This should not be in universal setting.
<img width="1080" alt="screen shot 2019-01-07 at 3 31 30 pm" src="https://user-images.githubusercontent.com/12286472/50757296-6d034700-1291-11e9-9b3f-950063cadd37.png">
