### PR TITLE
[ready] Esier resize pane

### DIFF
--- a/janus/vim/tmux.conf
+++ b/janus/vim/tmux.conf
@@ -19,10 +19,10 @@ bind-key -T copy-mode-vi C-k select-pane -U
 bind-key -T copy-mode-vi C-l select-pane -R
 bind-key -T copy-mode-vi C-\ select-pane -l
 pane_resize="5"
-bind-key -r H resize-pane -L "$pane_resize"
-bind-key -r J resize-pane -D "$pane_resize"
-bind-key -r K resize-pane -U "$pane_resize"
-bind-key -r L resize-pane -R "$pane_resize"
+bind-key -r h resize-pane -L "$pane_resize"
+bind-key -r j resize-pane -D "$pane_resize"
+bind-key -r k resize-pane -U "$pane_resize"
+bind-key -r l resize-pane -R "$pane_resize"
 
 # Mouse
 bind-key : command-prompt


### PR DESCRIPTION
Remap resize pane shortcut to `` ` + h(j, k, l)``, instead of `` ` + shift + h(j, k, l)``, which is very uncomfortable to press, `` ` + h(j, k, l)`` also seems more in rhythm with `Ctrl + h(j, k, l)`, which is to move arounds.
