### PR TITLE
[ready] Replace zoomwin with zoomwintab

### DIFF
--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -91,7 +91,7 @@ Plugin 'terryma/vim-multiple-cursors'
 Plugin 'thinca/vim-visualstar'
 Plugin 'bronson/vim-trailing-whitespace'
 Plugin 'airblade/vim-gitgutter'
-Plugin 'sh-dude/ZoomWin'
+Plugin 'troydm/zoomwintab.vim'
 
 if filereadable(expand("~/.vimrc.before"))
   source ~/.vimrc.before


### PR DESCRIPTION
With ZoomWin, the error occurred whenever zoomwin is turned on

<img width="1092" alt="1__remitano__zsh_" src="https://user-images.githubusercontent.com/344684/55702107-e0476100-5a18-11e9-8d67-3dea31d04ba4.png">

it's addressed at https://github.com/neovim/neovim/issues/997 

Solution: Use https://github.com/troydm/zoomwintab.vim instead.

Press `<Ctrl-w>o` or `<Ctrl-w><Ctrl-o>` to zoom in current window or use ZoomWinTabIn command
Press `<Ctrl-w>o` or `<Ctrl-w><Ctrl-o>` again to zoom out current window or use ZoomWinTabOut command

You can toggle between zoom in and out using ZoomWinTabToggle command

