### PR TITLE
[ready] Use system clipboard for copy/paste in vim

### DIFF
--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -217,3 +217,6 @@ imap <C-s> <Esc>:w<CR>i
 
 " Ctrl + A to select all
 map <C-a> <esc>ggVG<CR>
+
+" Use system clipboard for copy/paste in vim
+set clipboard=unnamedplus


### PR DESCRIPTION
Now when you wanna copy, paste from vim to other apps, `y/p` would work. No need for `"*y/"*p`.
I don't see any use case for separating vim registers & system clipboard for copy/paste functionality.
