### PR TITLE
[ready] Add inline-lint

### DIFF
--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -55,6 +55,7 @@ Plug 'tpope/vim-abolish'
 Plug 'tmux-plugins/vim-tmux-focus-events'
 Plug 'Yggdroot/LeaderF'
 Plug 'drmingdrmer/vim-toggle-quickfix'
+Plug 'dense-analysis/ale'
 "
 
 " Moved from Janus submodules


### PR DESCRIPTION
We have husky that will run lint-staged & bark about our lint issues when we commit code.
But I find that it's even better if we can show the issue right when the user is editing a file. So he can fix it right away.
Luckily, ALE (Asynchronous Lint Engine) Vim Plugin let us do just that.
![2020-03-17_10-58](https://user-images.githubusercontent.com/12286472/76820820-c6281c80-683e-11ea-9d77-2af9444c3da1.png)

This works for both javascript & ruby, which is heavily used in our code base.